### PR TITLE
Feature  - Coverage API updates

### DIFF
--- a/src/Sdk/Coverage/Coverage.ts
+++ b/src/Sdk/Coverage/Coverage.ts
@@ -11,6 +11,8 @@ import {
     CoverageUpdateRequest,
 } from './types';
 
+type CoverageId = Coverage['id'];
+
 export default class CoverageSdk {
     private readonly apiClient: ApiClient;
 
@@ -32,7 +34,7 @@ export default class CoverageSdk {
         return response.payload;
     }
 
-    async get(itemOrItemId: number | Coverage, includeDeleted = false): Promise<Coverage> {
+    async get(itemOrItemId: CoverageId | Coverage, includeDeleted = false): Promise<Coverage> {
         const url = buildUriWithId(routing.coverageUrl, itemOrItemId);
         const response = await this.apiClient.get<{ coverage: Coverage }>(url, {
             query: {
@@ -59,7 +61,7 @@ export default class CoverageSdk {
     }
 
     async update(
-        itemOrItemId: number | Coverage,
+        itemOrItemId: CoverageId | Coverage,
         payload: CoverageUpdateRequest,
     ): Promise<Coverage> {
         const response = await this.apiClient.patch<{ coverage: Coverage }>(
@@ -69,7 +71,7 @@ export default class CoverageSdk {
         return response.payload.coverage;
     }
 
-    async remove(itemOrItemId: string | Coverage): Promise<void> {
+    async remove(itemOrItemId: CoverageId | Coverage): Promise<void> {
         await this.apiClient.delete(buildUriWithId(routing.coverageUrl, itemOrItemId));
     }
 }

--- a/src/Sdk/Coverage/Coverage.ts
+++ b/src/Sdk/Coverage/Coverage.ts
@@ -24,7 +24,7 @@ export default class CoverageSdk {
             query: {
                 include_deleted: includeDeleted ? '✓' : undefined,
                 page,
-                pageSize,
+                limit: pageSize,
                 query: jsonQuery,
                 sort: sortOrder,
             },

--- a/src/Sdk/Coverage/Coverage.ts
+++ b/src/Sdk/Coverage/Coverage.ts
@@ -19,9 +19,10 @@ export default class CoverageSdk {
     }
 
     async list(options: CoverageSearchOptions = {}): Promise<CoverageListResponse> {
-        const { jsonQuery, page, pageSize, sortOrder } = options;
+        const { includeDeleted, jsonQuery, page, pageSize, sortOrder } = options;
         const response = await this.apiClient.get<CoverageListResponse>(routing.coverageUrl, {
             query: {
+                include_deleted: includeDeleted ? '✓' : undefined,
                 page,
                 pageSize,
                 query: jsonQuery,
@@ -31,16 +32,22 @@ export default class CoverageSdk {
         return response.payload;
     }
 
-    async get(itemOrItemId: number | Coverage): Promise<Coverage> {
-        const response = await this.apiClient.get<{ coverage: Coverage }>(
-            buildUriWithId(routing.coverageUrl, itemOrItemId),
-        );
+    async get(itemOrItemId: number | Coverage, includeDeleted = false): Promise<Coverage> {
+        const url = buildUriWithId(routing.coverageUrl, itemOrItemId);
+        const response = await this.apiClient.get<{ coverage: Coverage }>(url, {
+            query: {
+                include_deleted: includeDeleted ? '✓' : undefined,
+            },
+        });
         return response.payload.coverage;
     }
 
     async getByExternalReferenceId(externalReferenceId: string): Promise<Coverage | null> {
         const jsonQuery = JSON.stringify({ external_reference_id: { $in: [externalReferenceId] } });
-        const { coverage } = await this.list({ jsonQuery });
+        const { coverage } = await this.list({
+            includeDeleted: true,
+            jsonQuery,
+        });
         return coverage[0] || null;
     }
 

--- a/src/Sdk/Coverage/Coverage.ts
+++ b/src/Sdk/Coverage/Coverage.ts
@@ -31,7 +31,7 @@ export default class CoverageSdk {
         return response.payload;
     }
 
-    async get(itemOrItemId: string | Coverage): Promise<Coverage> {
+    async get(itemOrItemId: number | Coverage): Promise<Coverage> {
         const response = await this.apiClient.get<{ coverage: Coverage }>(
             buildUriWithId(routing.coverageUrl, itemOrItemId),
         );
@@ -52,7 +52,7 @@ export default class CoverageSdk {
     }
 
     async update(
-        itemOrItemId: string | Coverage,
+        itemOrItemId: number | Coverage,
         payload: CoverageUpdateRequest,
     ): Promise<Coverage> {
         const response = await this.apiClient.patch<{ coverage: Coverage }>(

--- a/src/Sdk/Coverage/Coverage.ts
+++ b/src/Sdk/Coverage/Coverage.ts
@@ -22,7 +22,7 @@ export default class CoverageSdk {
         const { includeDeleted, jsonQuery, page, pageSize, sortOrder } = options;
         const response = await this.apiClient.get<CoverageListResponse>(routing.coverageUrl, {
             query: {
-                include_deleted: includeDeleted ? '✓' : undefined,
+                include_deleted: includeDeleted ? 'on' : undefined,
                 page,
                 limit: pageSize,
                 query: jsonQuery,
@@ -36,7 +36,7 @@ export default class CoverageSdk {
         const url = buildUriWithId(routing.coverageUrl, itemOrItemId);
         const response = await this.apiClient.get<{ coverage: Coverage }>(url, {
             query: {
-                include_deleted: includeDeleted ? '✓' : undefined,
+                include_deleted: includeDeleted ? 'on' : undefined,
             },
         });
         return response.payload.coverage;

--- a/src/Sdk/Coverage/types.ts
+++ b/src/Sdk/Coverage/types.ts
@@ -10,7 +10,7 @@ export interface CoverageUpdateRequest {
     note_content?: string | { json: string } | { text: string };
     organisation?: Contact['id'] | string | null;
     original_metadata_source?: string;
-    published_at?: string;
+    published_at?: string | null;
     story?: Story['id'] | null;
     url?: string | null;
 }

--- a/src/Sdk/Coverage/types.ts
+++ b/src/Sdk/Coverage/types.ts
@@ -5,6 +5,7 @@ export interface CoverageUpdateRequest {
     attachment?: string | null;
     author?: Contact['id'] | string | null;
     external_reference_id?: string;
+    headline?: string;
     newsroom?: RoomRef['id'] | null;
     note_content?: string | { json: string } | { text: string };
     organisation?: Contact['id'] | string | null;

--- a/src/Sdk/Coverage/types.ts
+++ b/src/Sdk/Coverage/types.ts
@@ -18,6 +18,7 @@ export interface CoverageUpdateRequest {
 export interface CoverageCreateRequest extends CoverageUpdateRequest {}
 
 export interface CoverageSearchOptions {
+    includeDeleted?: boolean;
     jsonQuery?: string;
     page?: number;
     pageSize?: number;

--- a/src/Sdk/Sdk.test.js
+++ b/src/Sdk/Sdk.test.js
@@ -90,7 +90,7 @@ describe('Sdk', () => {
             });
             const result = await prezlySdk.coverage.getByExternalReferenceId(externalReferenceId);
 
-            const search = `?query=%7B%22external_reference_id%22%3A%7B%22%24in%22%3A%5B%22${externalReferenceId}%22%5D%7D%7D`;
+            const search = `?include_deleted=on&query=%7B%22external_reference_id%22%3A%7B%22%24in%22%3A%5B%22${externalReferenceId}%22%5D%7D%7D`;
             expect(fetch).toHaveBeenCalledWith(`${defaultCoverageApiUrl}${search}`, {
                 ...DEFAULT_REQUEST_PROPS,
                 method: Method.GET,

--- a/src/Sdk/utils.ts
+++ b/src/Sdk/utils.ts
@@ -11,7 +11,7 @@ export const stripSlashes = (url: string): string => url.replace(/^\/|\/$/g, '')
 
 export function buildUriWithId(
     sdkUrl: string,
-    itemOrItemId: string | Entity<number | string>,
+    itemOrItemId: number | string | Entity<number | string>,
 ): string {
     const itemId = typeof itemOrItemId === 'object' ? itemOrItemId.id : itemOrItemId;
     return `${sdkUrl}/${itemId}`;

--- a/src/types/Coverage.ts
+++ b/src/types/Coverage.ts
@@ -16,6 +16,7 @@ export default interface Coverage extends Entity<string> {
         version: number;
     } | null;
     author_contact: Contact | null;
+    headline: string;
     organisation_contact: Contact | null;
     newsroom: RoomRef | null;
     note_content_html: string;

--- a/src/types/Coverage.ts
+++ b/src/types/Coverage.ts
@@ -4,7 +4,7 @@ import Story from './Story';
 import UserRef from './UserRef';
 import RoomRef from './RoomRef';
 
-export default interface Coverage extends Entity<string> {
+export default interface Coverage extends Entity<number> {
     attachment: {
         cdnUrl: string;
         download_url: string;

--- a/src/types/Coverage.ts
+++ b/src/types/Coverage.ts
@@ -24,10 +24,10 @@ export default interface Coverage extends Entity<number> {
     note_content_text: string;
     created_at: string;
     edited_at: string | null;
-    published_at: string;
+    published_at: string | null;
     story: Story | null;
     updated_at: string;
-    url: string;
+    url: string | null;
     user: UserRef;
     view_url: string;
 }

--- a/src/types/Coverage.ts
+++ b/src/types/Coverage.ts
@@ -17,6 +17,7 @@ export default interface Coverage extends Entity<number> {
     } | null;
     author_contact: Contact | null;
     headline: string;
+    is_deleted: boolean;
     organisation_contact: Contact | null;
     newsroom: RoomRef | null;
     note_content_html: string;


### PR DESCRIPTION
- Fix a bug with `pageSize` not being passed as `limit` request param

- Fix wrong coverage ID type (it is actually `number`, but `string` was declared before)

- Update Coverage interface with the latest changes in Prezly APIs (`url` and `published_at` properties)

- Add support for `headline` property
     https://app.clubhouse.io/prezly/story/11641/update-prezly-sdk-package
  
   - Add new `headline` property to Coverage interface
   - Add new `headline?` property to Coverage create/update requests

   <br>

- Add support for soft-deleted coverage
   https://app.clubhouse.io/prezly/story/13255/update-prezly-javascript-sdk

   - Add new `is_deleted` property to Coverage interface
   - Add new `include_deleted` param to Coverage List API function
   - Always use `include_deleted: true` for `external_reference_id` lookups

