### PR TITLE
Refactor - Drop support for ID or Object parameters

### DIFF
--- a/src/Sdk/Coverage/Coverage.ts
+++ b/src/Sdk/Coverage/Coverage.ts
@@ -2,7 +2,6 @@ import { Coverage } from '../../types';
 
 import routing from '../routing';
 import ApiClient from '../ApiClient';
-import { buildUriWithId } from '../utils';
 
 import {
     CoverageCreateRequest,
@@ -34,8 +33,8 @@ export default class CoverageSdk {
         return response.payload;
     }
 
-    async get(itemOrItemId: CoverageId | Coverage, includeDeleted = false): Promise<Coverage> {
-        const url = buildUriWithId(routing.coverageUrl, itemOrItemId);
+    async get(id: CoverageId, includeDeleted = false): Promise<Coverage> {
+        const url = `${routing.coverageUrl}/${id}`;
         const response = await this.apiClient.get<{ coverage: Coverage }>(url, {
             query: {
                 include_deleted: includeDeleted ? 'on' : undefined,
@@ -60,18 +59,15 @@ export default class CoverageSdk {
         return response.payload.coverage;
     }
 
-    async update(
-        itemOrItemId: CoverageId | Coverage,
-        payload: CoverageUpdateRequest,
-    ): Promise<Coverage> {
+    async update(id: CoverageId, payload: CoverageUpdateRequest): Promise<Coverage> {
         const response = await this.apiClient.patch<{ coverage: Coverage }>(
-            buildUriWithId(routing.coverageUrl, itemOrItemId),
+            `${routing.coverageUrl}/${id}`,
             { payload },
         );
         return response.payload.coverage;
     }
 
-    async remove(itemOrItemId: CoverageId | Coverage): Promise<void> {
-        await this.apiClient.delete(buildUriWithId(routing.coverageUrl, itemOrItemId));
+    async remove(id: CoverageId): Promise<void> {
+        await this.apiClient.delete(`${routing.coverageUrl}/${id}`);
     }
 }

--- a/src/Sdk/utils.ts
+++ b/src/Sdk/utils.ts
@@ -1,5 +1,3 @@
-import { Entity } from '../types';
-
 /**
  * Remove heading and trailing slashes.
  * Examples:
@@ -8,11 +6,3 @@ import { Entity } from '../types';
  *  - /v2/path/ -> v2/path
  */
 export const stripSlashes = (url: string): string => url.replace(/^\/|\/$/g, '');
-
-export function buildUriWithId(
-    sdkUrl: string,
-    itemOrItemId: number | string | Entity<number | string>,
-): string {
-    const itemId = typeof itemOrItemId === 'object' ? itemOrItemId.id : itemOrItemId;
-    return `${sdkUrl}/${itemId}`;
-}


### PR DESCRIPTION
Drop support for ID or Object parameters

- SDK functions do only accept ids now
- Drop unneeded now `buildUriWithId()` function