### PR TITLE
[DEV-2437] Fix - Undocumented API properties

### DIFF
--- a/src/types/Coverage.ts
+++ b/src/types/Coverage.ts
@@ -3,6 +3,8 @@ import Entity from './Entity';
 import { NewsroomRef } from './Newsroom';
 import Story from './Story';
 import UserRef from './UserRef';
+import { UploadcareImageStoragePayload } from '@prezly/slate-types';
+import { OEmbedInfo } from './common';
 
 export default interface Coverage extends Entity<number> {
     uuid: string;
@@ -11,30 +13,26 @@ export default interface Coverage extends Entity<number> {
      * @see uuid
      */
     id: number;
-    attachment: {
-        cdnUrl: string;
-        download_url: string;
-        filename: string;
-        isImage: boolean;
-        mime_type: string;
-        size: number;
-        uuid: string;
-        version: number;
-    } | null;
-    author_contact: Contact | null;
-    headline: string;
     is_deleted: boolean;
-    organisation_contact: Contact | null;
+    headline: string;
+    user: UserRef;
+    story: Story | null;
     newsroom: NewsroomRef | null;
+    author_contact: Contact | null;
+    organisation_contact: Contact | null;
+    url: string | null;
     note_content_html: string;
     note_content_json: string;
     note_content_text: string;
-    created_at: string;
-    edited_at: string | null;
+    attachment: UploadcareImageStoragePayload;
+    attachment_oembed: OEmbedInfo | null;
+
     published_at: string | null;
-    story: Story | null;
+    created_at: string;
     updated_at: string;
-    url: string | null;
-    user: UserRef;
+    edited_at: string | null;
+    /**
+     * @deprecated Please don't rely on this prop. It will be removed in future.
+     */
     view_url: string;
 }

--- a/src/types/Coverage.ts
+++ b/src/types/Coverage.ts
@@ -13,6 +13,7 @@ export default interface Coverage extends Entity<number> {
      * @see uuid
      */
     id: number;
+    display_name: string;
     is_deleted: boolean;
     headline: string;
     user: UserRef;
@@ -31,6 +32,10 @@ export default interface Coverage extends Entity<number> {
     created_at: string;
     updated_at: string;
     edited_at: string | null;
+    /**
+     * @deprecated Please don't rely on this prop. It will be removed in future.
+     */
+    avatar_url: string;
     /**
      * @deprecated Please don't rely on this prop. It will be removed in future.
      */

--- a/src/types/Newsroom.ts
+++ b/src/types/Newsroom.ts
@@ -1,4 +1,5 @@
 import Culture from './Culture';
+import { UploadcareImageStoragePayload } from '@prezly/slate-types';
 
 export interface NewsroomRef {
     uuid: string;
@@ -51,4 +52,7 @@ export default interface Newsroom extends NewsroomRef {
     cultures: Culture[];
     campaigns_number: number;
     stories_number: number;
+    // assets
+    square_logo: UploadcareImageStoragePayload | null;
+    newsroom_logo: UploadcareImageStoragePayload | null;
 }


### PR DESCRIPTION
DEV-2437

- Add undocumented Newsroom API properties: `newsroom_logo`  and `square_logo`
- Add undocumented Coverage API properties: `display_name` and `avatar_url` (+apply logical order)