### PR TITLE
[DEV-2461] Update tsconfig to not remove JSDoc comments

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "module": "commonjs",
         "lib": ["esnext", "dom"],
         "outDir": "./dist",
-        "removeComments": true,
+        "removeComments": false,
         "inlineSourceMap": true,
         "inlineSources": true,
         "downlevelIteration": true,


### PR DESCRIPTION
The TypeScript docs confusingly don't specify that `removeComments` option is only applying to JSDoc comments, and that regular comments are always removed on build regardless of this setting.

Update the value to `false`, so now all JSDoc comments on interfaces should be preserved.