### PR TITLE
[DEV-2646] Feature - Stories SDK include sparse fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,4 @@ const PrezlySdk = require('@prezly/sdk').default;
 ```
 
 We recommend referring to the [official `cross-fetch` module documentation](https://www.npmjs.com/package/cross-fetch) for more information.
+

--- a/src/Sdk/Stories/Stories.ts
+++ b/src/Sdk/Stories/Stories.ts
@@ -27,14 +27,17 @@ export default class Stories {
             : Story
     >(options?: Options): Promise<StoriesListResponse<StoryRecord>> {
         const { limit, offset, sortOrder, include } = options || {};
-        const response = await this.apiClient.get<StoriesListResponse<StoryRecord>>(routing.storiesUrl, {
-            query: {
-                limit,
-                offset,
-                sort: sortOrder,
-                include: include ? include.join(',') : undefined,
+        const response = await this.apiClient.get<StoriesListResponse<StoryRecord>>(
+            routing.storiesUrl,
+            {
+                query: {
+                    limit,
+                    offset,
+                    sort: sortOrder,
+                    include: include ? include.join(',') : undefined,
+                },
             },
-        });
+        );
         return response.payload;
     }
 

--- a/src/Sdk/Stories/Stories.ts
+++ b/src/Sdk/Stories/Stories.ts
@@ -1,4 +1,4 @@
-import { ExtendedStory, Story } from '../../types';
+import { ExtendedStory, ExtraStoryFields, Story } from '../../types';
 
 import routing from '../routing';
 import ApiClient from '../ApiClient';
@@ -19,28 +19,34 @@ export default class Stories {
         this.apiClient = apiClient;
     }
 
-    async list({ limit, offset, sortOrder }: StoriesListRequest = {}): Promise<
-        StoriesListResponse
-    > {
-        const response = await this.apiClient.get<StoriesListResponse>(routing.storiesUrl, {
+    async list<
+        I extends keyof ExtraStoryFields = never,
+        S extends Story = Story & Pick<ExtraStoryFields, I>,
+    >(options?: StoriesListRequest<I>): Promise<StoriesListResponse<S>> {
+        const { limit, offset, sortOrder, include } = options || {};
+        const response = await this.apiClient.get<StoriesListResponse<S>>(routing.storiesUrl, {
             query: {
                 limit,
                 offset,
                 sort: sortOrder,
+                include: include ? include.join(',') : undefined,
             },
         });
         return response.payload;
     }
 
-    async search({ jsonQuery, limit, offset, sortOrder }: StoriesSearchRequest = {}): Promise<
-        StoriesListResponse
-    > {
-        const response = await this.apiClient.post<StoriesListResponse>(routing.storiesSearchUrl, {
+    async search<
+        I extends keyof ExtraStoryFields = never,
+        S extends Story = Story & Pick<ExtraStoryFields, I>,
+    >(options?: StoriesSearchRequest<I>): Promise<StoriesListResponse<S>> {
+        const { limit, offset, sortOrder, include, jsonQuery } = options || {};
+        const response = await this.apiClient.post<StoriesListResponse<S>>(routing.storiesSearchUrl, {
             payload: {
                 query: jsonQuery,
                 limit,
                 offset,
                 sort: sortOrder,
+                include: include ? include.join(',') : undefined,
             },
         });
         return response.payload;

--- a/src/Sdk/Stories/Stories.ts
+++ b/src/Sdk/Stories/Stories.ts
@@ -20,11 +20,14 @@ export default class Stories {
     }
 
     async list<
-        I extends keyof ExtraStoryFields = never,
-        S extends Story = Story & Pick<ExtraStoryFields, I>
-    >(options?: StoriesListRequest<I>): Promise<StoriesListResponse<S>> {
+        Include extends readonly (keyof ExtraStoryFields)[],
+        Options extends StoriesListRequest<Include>,
+        StoryRecord extends Story = Options['include'] extends Include
+            ? Story & Pick<ExtraStoryFields, Options['include'][number]>
+            : Story
+    >(options?: Options): Promise<StoriesListResponse<StoryRecord>> {
         const { limit, offset, sortOrder, include } = options || {};
-        const response = await this.apiClient.get<StoriesListResponse<S>>(routing.storiesUrl, {
+        const response = await this.apiClient.get<StoriesListResponse<StoryRecord>>(routing.storiesUrl, {
             query: {
                 limit,
                 offset,
@@ -36,11 +39,14 @@ export default class Stories {
     }
 
     async search<
-        I extends keyof ExtraStoryFields = never,
-        S extends Story = Story & Pick<ExtraStoryFields, I>
-    >(options?: StoriesSearchRequest<I>): Promise<StoriesListResponse<S>> {
+        Include extends readonly (keyof ExtraStoryFields)[],
+        Options extends StoriesListRequest<Include>,
+        StoryRecord extends Story = Options['include'] extends Include
+            ? Story & Pick<ExtraStoryFields, Options['include'][number]>
+            : Story
+    >(options?: StoriesSearchRequest<Include>): Promise<StoriesListResponse<StoryRecord>> {
         const { limit, offset, sortOrder, include, jsonQuery } = options || {};
-        const response = await this.apiClient.post<StoriesListResponse<S>>(
+        const response = await this.apiClient.post<StoriesListResponse<StoryRecord>>(
             routing.storiesSearchUrl,
             {
                 payload: {

--- a/src/Sdk/Stories/Stories.ts
+++ b/src/Sdk/Stories/Stories.ts
@@ -21,7 +21,7 @@ export default class Stories {
 
     async list<
         I extends keyof ExtraStoryFields = never,
-        S extends Story = Story & Pick<ExtraStoryFields, I>,
+        S extends Story = Story & Pick<ExtraStoryFields, I>
     >(options?: StoriesListRequest<I>): Promise<StoriesListResponse<S>> {
         const { limit, offset, sortOrder, include } = options || {};
         const response = await this.apiClient.get<StoriesListResponse<S>>(routing.storiesUrl, {
@@ -37,18 +37,21 @@ export default class Stories {
 
     async search<
         I extends keyof ExtraStoryFields = never,
-        S extends Story = Story & Pick<ExtraStoryFields, I>,
+        S extends Story = Story & Pick<ExtraStoryFields, I>
     >(options?: StoriesSearchRequest<I>): Promise<StoriesListResponse<S>> {
         const { limit, offset, sortOrder, include, jsonQuery } = options || {};
-        const response = await this.apiClient.post<StoriesListResponse<S>>(routing.storiesSearchUrl, {
-            payload: {
-                query: jsonQuery,
-                limit,
-                offset,
-                sort: sortOrder,
-                include: include ? include.join(',') : undefined,
+        const response = await this.apiClient.post<StoriesListResponse<S>>(
+            routing.storiesSearchUrl,
+            {
+                payload: {
+                    query: jsonQuery,
+                    limit,
+                    offset,
+                    sort: sortOrder,
+                    include: include ? include.join(',') : undefined,
+                },
             },
-        });
+        );
         return response.payload;
     }
 

--- a/src/Sdk/Stories/types.ts
+++ b/src/Sdk/Stories/types.ts
@@ -1,6 +1,7 @@
 import {
     Category,
     Culture,
+    ExtraStoryFields,
     NewsroomRef,
     Pagination,
     Story,
@@ -8,20 +9,47 @@ import {
     StoryVisibility,
 } from '../../types';
 
-export interface StoriesListRequest {
+/**
+ * @see https://github.com/microsoft/TypeScript/issues/13298#issuecomment-707364842
+ */
+type UnionToTuple<T> = (
+    (
+        (
+            T extends any
+                ? (t: T) => T
+                : never
+            ) extends infer U
+            ? (U extends any
+            ? (u: U) => any
+            : never
+                ) extends (v: infer V) => any
+            ? V
+            : never
+            : never
+        ) extends (_: any) => infer W
+        ? [...UnionToTuple<Exclude<T, W>>, W]
+        : []
+    );
+
+export type StoriesSearchRequest<I extends keyof ExtraStoryFields = never> = {
+    jsonQuery?: string;
     limit?: number;
     offset?: number;
     sortOrder?: string;
-}
-export interface StoriesSearchRequest extends StoriesListRequest {
+} & (
     /**
-     * Filter query using Prezly JSON Query Language
+     * Note: [I] extends [never] is required here (see https://stackoverflow.com/a/65492934).
      */
-    jsonQuery?: string;
-}
+    [I] extends [never] ? {
+        include?: never;
+    } : {
+        include: UnionToTuple<I>;
+    });
 
-export interface StoriesListResponse {
-    stories: Story[];
+export type StoriesListRequest<I extends keyof ExtraStoryFields = never> = Omit<StoriesSearchRequest<I>, 'jsonQuery'>;
+
+export interface StoriesListResponse<S extends Story = Story> {
+    stories: S[];
     pagination: Pagination;
     sort: string;
 }

--- a/src/Sdk/Stories/types.ts
+++ b/src/Sdk/Stories/types.ts
@@ -12,41 +12,38 @@ import {
 /**
  * @see https://github.com/microsoft/TypeScript/issues/13298#issuecomment-707364842
  */
-type UnionToTuple<T> = (
-    (
-        (
-            T extends any
-                ? (t: T) => T
-                : never
-            ) extends infer U
-            ? (U extends any
-            ? (u: U) => any
-            : never
-                ) extends (v: infer V) => any
-            ? V
-            : never
-            : never
-        ) extends (_: any) => infer W
-        ? [...UnionToTuple<Exclude<T, W>>, W]
-        : []
-    );
+type UnionToTuple<T> = ((T extends any
+  ? (t: T) => T
+  : never) extends infer U
+  ? (U extends any
+      ? (u: U) => any
+      : never) extends (v: infer V) => any
+      ? V
+      : never
+  : never) extends (_: any) => infer W
+    ? [...UnionToTuple<Exclude<T, W>>, W]
+    : [];
 
 export type StoriesSearchRequest<I extends keyof ExtraStoryFields = never> = {
     jsonQuery?: string;
     limit?: number;
     offset?: number;
     sortOrder?: string;
-} & (
-    /**
-     * Note: [I] extends [never] is required here (see https://stackoverflow.com/a/65492934).
-     */
-    [I] extends [never] ? {
-        include?: never;
-    } : {
-        include: UnionToTuple<I>;
-    });
+} & /**
+ * Note: [I] extends [never] is required here (see https://stackoverflow.com/a/65492934).
+ */
+([I] extends [never]
+    ? {
+          include?: never;
+      }
+    : {
+          include: UnionToTuple<I>;
+      });
 
-export type StoriesListRequest<I extends keyof ExtraStoryFields = never> = Omit<StoriesSearchRequest<I>, 'jsonQuery'>;
+export type StoriesListRequest<I extends keyof ExtraStoryFields = never> = Omit<
+    StoriesSearchRequest<I>,
+    'jsonQuery'
+>;
 
 export interface StoriesListResponse<S extends Story = Story> {
     stories: S[];

--- a/src/Sdk/Stories/types.ts
+++ b/src/Sdk/Stories/types.ts
@@ -29,10 +29,7 @@ export type StoriesSearchRequest<I extends keyof ExtraStoryFields = never> = {
     limit?: number;
     offset?: number;
     sortOrder?: string;
-} & /**
- * Note: [I] extends [never] is required here (see https://stackoverflow.com/a/65492934).
- */
-([I] extends [never]
+} & ([I] extends [never] // Note: [I] extends [never] is required (see https://stackoverflow.com/a/65492934)
     ? {
           include?: never;
       }

--- a/src/Sdk/Stories/types.ts
+++ b/src/Sdk/Stories/types.ts
@@ -9,36 +9,15 @@ import {
     StoryVisibility,
 } from '../../types';
 
-/**
- * @see https://github.com/microsoft/TypeScript/issues/13298#issuecomment-707364842
- */
-type UnionToTuple<T> = ((T extends any
-  ? (t: T) => T
-  : never) extends infer U
-  ? (U extends any
-      ? (u: U) => any
-      : never) extends (v: infer V) => any
-      ? V
-      : never
-  : never) extends (_: any) => infer W
-    ? [...UnionToTuple<Exclude<T, W>>, W]
-    : [];
-
-export type StoriesSearchRequest<I extends keyof ExtraStoryFields = never> = {
+export type StoriesSearchRequest<Include extends readonly (keyof ExtraStoryFields)[]> = {
     jsonQuery?: string;
     limit?: number;
     offset?: number;
     sortOrder?: string;
-} & ([I] extends [never] // Note: [I] extends [never] is required (see https://stackoverflow.com/a/65492934)
-    ? {
-          include?: never;
-      }
-    : {
-          include: UnionToTuple<I>;
-      });
-
-export type StoriesListRequest<I extends keyof ExtraStoryFields = never> = Omit<
-    StoriesSearchRequest<I>,
+    include?: Include;
+};
+export type StoriesListRequest<Include extends readonly (keyof ExtraStoryFields)[]> = Omit<
+    StoriesSearchRequest<Include>,
     'jsonQuery'
 >;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,8 @@ export {
     OEmbedInfo,
     Pagination,
     Story,
+    ExtendedStory,
+    ExtraStoryFields,
     StoryRef,
     StoryVisibility,
     StoryPublicationStatus,

--- a/src/types/Story.ts
+++ b/src/types/Story.ts
@@ -120,7 +120,7 @@ export default interface Story extends Entity<number> {
     visibility: Visibility;
 }
 
-export interface ExtendedStory extends Story {
+export interface ExtraStoryFields {
     /**
      * Depending on `format_version` this field can contain:
      * - HTML content for v1 stories (deprecated)
@@ -142,3 +142,5 @@ export interface ExtendedStory extends Story {
     social_text: string;
     tag_names: string[];
 }
+
+export interface ExtendedStory extends Story, ExtraStoryFields {}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,7 @@ export {
     default as Story,
     StoryRef,
     ExtendedStory,
+    ExtraStoryFields,
     FormatVersion as StoryFormatVersion,
     LifecycleStatus as StoryLifecycleStatus,
     PublicationStatus as StoryPublicationStatus,


### PR DESCRIPTION
DEV-2646

- Update SDK to support optional fields includes. 
  It is now possible to fetch stories list with `ExtendedStory` fields

### Usage

```js
const { stories } = await api.list({ include: ['content', 'preview_image'] });
```

Thanks @yuriyyakym for dramatic simplification of the proposed solution :trophy: 