### PR TITLE
Fix - Add screenshot_url attribute to OEmbedInfo

### DIFF
--- a/src/types/common/OEmbedInfo.ts
+++ b/src/types/common/OEmbedInfo.ts
@@ -6,6 +6,7 @@ export default interface OEmbedInfo {
     // generic properties
     title?: string;
     description?: string;
+    screenshot_url?: string;
     thumbnail_url?: string;
     thumbnail_width?: string;
     thumbnail_height?: string;


### PR DESCRIPTION
Required for https://github.com/prezly/slate/pull/23/files
