### PR TITLE
[DEV-3248][DEV-3249] Fix - Newsroom categories SDK

### DIFF
--- a/src/Sdk/NewsroomCategories/NewsroomCategories.ts
+++ b/src/Sdk/NewsroomCategories/NewsroomCategories.ts
@@ -31,6 +31,12 @@ export default class NewsroomCategories {
         return response.payload.categories;
     }
 
+    public async get(newsroomId: NewsroomId, categoryId: Category['id']): Promise<Category> {
+        const url = routing.newsroomCategoriesUrl.replace(':newsroom_id', String(newsroomId));
+        const response = await this.apiClient.get<{ category: Category }>(`${url}/${categoryId}`);
+        return response.payload.category;
+    }
+
     public async create(
         newsroomId: NewsroomId,
         payload: NewsroomCategoryCreateRequest,

--- a/src/Sdk/NewsroomCategories/NewsroomCategories.ts
+++ b/src/Sdk/NewsroomCategories/NewsroomCategories.ts
@@ -50,10 +50,11 @@ export default class NewsroomCategories {
 
     public async update(
         newsroomId: NewsroomId,
+        categoryId: Category['id'],
         payload: NewsroomCategoryUpdateRequest,
     ): Promise<Category> {
         const url = routing.newsroomCategoriesUrl.replace(':newsroom_id', String(newsroomId));
-        const response = await this.apiClient.post<{ category: Category }>(url, {
+        const response = await this.apiClient.post<{ category: Category }>(`${url}/${categoryId}`, {
             payload,
         });
         return response.payload.category;


### PR DESCRIPTION
https://linear.app/prezly/issue/DEV-3248/newsroom-categories-api-cannot-update-particular-category
https://linear.app/prezly/issue/DEV-3249/newsroom-categories-api-cannot-get-particular-category

- adds `NewsroomCategories.get`
- adds `categoryId` argument to `NewsroomCategories.update`