### PR TITLE
Fix `NotificationSubscriptions.UpdateRequest` type

### DIFF
--- a/src/endpoints/NotificationSubscriptions/types.ts
+++ b/src/endpoints/NotificationSubscriptions/types.ts
@@ -2,7 +2,7 @@ import type { NotificationSubscription } from '../../types';
 
 interface SubscriptionUpdate {
     notification_type: NotificationSubscription.Type['id'];
-    is_email_subscribed: NotificationSubscription['is_email_required'];
+    is_email_subscribed: NotificationSubscription['is_email_subscribed'];
 }
 
 export interface UpdateRequest {

--- a/src/endpoints/NotificationSubscriptions/types.ts
+++ b/src/endpoints/NotificationSubscriptions/types.ts
@@ -1,5 +1,10 @@
 import type { NotificationSubscription } from '../../types';
 
+interface SubscriptionUpdate {
+    notification_type: NotificationSubscription.Type['id'];
+    is_email_subscribed: NotificationSubscription['is_email_required'];
+}
+
 export interface UpdateRequest {
-    subscriptions: Pick<NotificationSubscription, 'notification_type' | 'is_email_subscribed'>[];
+    subscriptions: SubscriptionUpdate[];
 }


### PR DESCRIPTION
This issue was introduced in #164. The API expects just the string id in the `notification_type` field, not the whole Type object