### PR TITLE
[DEV-9717] Fix - Newsroom Google Analytics ID prop consistency

### DIFF
--- a/src/types/Newsroom.ts
+++ b/src/types/Newsroom.ts
@@ -99,9 +99,14 @@ export interface Newsroom extends NewsroomRef {
         is_enabled: boolean;
         category: string | null;
     };
+    google_analytics_id: string | null;
+    /**
+     * @deprecated Please use `google_analytics_id` instead.
+     * @see google_analytics_id
+     */
     ga_tracking_id: string | null;
-    segment_analytics_id: string | null;
     google_search_console_key: string | null;
+    segment_analytics_id: string | null;
 
     is_subscription_form_enabled: boolean;
     is_white_labeled: boolean;


### PR DESCRIPTION
- Introduce a consistent name for Newsroom Google Analytics tracking ID prop
  The old `ga_tracking_id` is a deprecated alias now.