### PR TITLE
[DEV-10125] Declare a new prop on Sender Domain API

### DIFF
--- a/src/types/SenderDomain.ts
+++ b/src/types/SenderDomain.ts
@@ -21,6 +21,11 @@ export interface SenderDomain {
      */
     is_upgrade_recommended: boolean;
     /**
+     * Indicate whether the domain is on a deprecated email verification setup.
+     * Upgrading is required.
+     */
+    is_upgrade_required: boolean;
+    /**
      * There were different verification setups we've been using over the years.
      * The latest one, which is also the best so far, is `v3`.
      */


### PR DESCRIPTION
It's `is_upgrade_required` to indicate that the domain is using a deprecated setup that has to be upgraded.