### PR TITLE
[DEV-10349] Change - Contact Duplicates API full record vs ref

### DIFF
--- a/src/types/Contact.ts
+++ b/src/types/Contact.ts
@@ -1,6 +1,6 @@
 import type { UploadedImage } from '@prezly/uploads';
 
-import type { ContactDuplicateSuggestion } from './ContactDuplicateSuggestion';
+import type { ContactDuplicateSuggestionRef } from './ContactDuplicateSuggestion';
 
 export interface ContactRef {
     id: number;
@@ -76,7 +76,7 @@ export interface Contact {
     is_unsubscribed: boolean;
     is_unsubscribed_from_all_communications: boolean;
     unsubscribed_newsrooms: string[];
-    duplicate_contacts: ContactDuplicateSuggestion[];
+    duplicate_contacts: ContactDuplicateSuggestionRef[];
 
     created_at: string | null; // there are contacts in DB that do have `created_at = null`
     modified_at: string | null;

--- a/src/types/Contact.ts
+++ b/src/types/Contact.ts
@@ -173,4 +173,26 @@ export namespace Contact {
             CELLPHONE = 'cell',
         }
     }
+
+    export function isPerson(contact: Pick<Contact, 'contact_type'>): boolean;
+    export function isPerson(type: Contact['contact_type']): boolean;
+    export function isPerson(
+        arg: Contact['contact_type'] | Pick<Contact, 'contact_type'>,
+    ): boolean {
+        if (arg !== null && typeof arg === 'object') {
+            return arg.contact_type === Type.PERSON;
+        }
+        return arg === Type.PERSON;
+    }
+
+    export function isOrganisation(contact: Pick<Contact, 'contact_type'>): boolean;
+    export function isOrganisation(type: Contact['contact_type']): boolean;
+    export function isOrganisation(
+        arg: Contact['contact_type'] | Pick<Contact, 'contact_type'>,
+    ): boolean {
+        if (arg !== null && typeof arg === 'object') {
+            return arg.contact_type === Type.ORGANISATION;
+        }
+        return arg === Type.ORGANISATION;
+    }
 }

--- a/src/types/ContactDuplicateSuggestion.ts
+++ b/src/types/ContactDuplicateSuggestion.ts
@@ -18,4 +18,37 @@ export namespace ContactDuplicateSuggestion {
         ACCEPTED = 'accepted',
         DECLINED = 'declined',
     }
+
+    export function isUnseen(suggestion: Pick<ContactDuplicateSuggestion, 'status'>): boolean;
+    export function isUnseen(status: ContactDuplicateSuggestion['status']): boolean;
+    export function isUnseen(
+        arg: Pick<ContactDuplicateSuggestion, 'status'> | ContactDuplicateSuggestion['status'],
+    ): boolean {
+        if (arg !== null && typeof arg === 'object') {
+            return arg.status === Status.UNSEEN;
+        }
+        return arg === Status.UNSEEN;
+    }
+
+    export function isAccepted(suggestion: Pick<ContactDuplicateSuggestion, 'status'>): boolean;
+    export function isAccepted(status: ContactDuplicateSuggestion['status']): boolean;
+    export function isAccepted(
+        arg: Pick<ContactDuplicateSuggestion, 'status'> | ContactDuplicateSuggestion['status'],
+    ): boolean {
+        if (arg !== null && typeof arg === 'object') {
+            return arg.status === Status.ACCEPTED;
+        }
+        return arg === Status.ACCEPTED;
+    }
+
+    export function isDeclined(suggestion: Pick<ContactDuplicateSuggestion, 'status'>): boolean;
+    export function isDeclined(status: ContactDuplicateSuggestion['status']): boolean;
+    export function isDeclined(
+        arg: Pick<ContactDuplicateSuggestion, 'status'> | ContactDuplicateSuggestion['status'],
+    ): boolean {
+        if (arg !== null && typeof arg === 'object') {
+            return arg.status === Status.DECLINED;
+        }
+        return arg === Status.DECLINED;
+    }
 }

--- a/src/types/ContactDuplicateSuggestion.ts
+++ b/src/types/ContactDuplicateSuggestion.ts
@@ -1,11 +1,22 @@
-import type { ContactRef } from './Contact';
+import type { Contact, ContactRef } from './Contact';
+
+/**
+ * Value in range 0.0 ... 1.0.
+ */
+type Score = number;
 
 export interface ContactDuplicateSuggestion {
-    contact: ContactRef;
-    /**
-     * Value in range 0.0 ... 1.0.
-     */
-    score: number;
+    contact: Contact; // Note: Contact
+    score: Score;
+    status: ContactDuplicateSuggestion.Status;
+    links: {
+        merge_api: string;
+    };
+}
+
+export interface ContactDuplicateSuggestionRef {
+    contact: ContactRef; // Note: ContactRef
+    score: Score;
     status: ContactDuplicateSuggestion.Status;
     links: {
         merge_api: string;


### PR DESCRIPTION
- Introduce a Ref projection of `ContactDuplicateSuggestion`, and use it inside `Contact.duplicate_contacts`
- While the full `ContactDuplicateSuggestion` (with full `Contact`) will now be used as a result of Contact Duplicates API