### PR TITLE
[CARE-1524] Add support for Edge Runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@prezly/sdk",
-    "version": "15.15.0",
+    "version": "15.15.1-0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@prezly/sdk",
-            "version": "15.15.0",
+            "version": "15.15.1-0",
             "license": "MIT",
             "dependencies": {
                 "@prezly/progress-promise": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@prezly/sdk",
-    "version": "15.15.0",
+    "version": "15.15.1-0",
     "description": "Prezly API SDK",
     "type": "module",
     "main": "dist/index.cjs",

--- a/src/http/lib.ts
+++ b/src/http/lib.ts
@@ -4,7 +4,22 @@ import * as nodeUrl from 'url';
 
 import type { DeferredJobResponse } from './types';
 
-const URL = typeof window === 'undefined' ? nodeUrl.URL : window.URL;
+/**
+ * Choose which `URL` class to use based on the environment (Browser / Node.js / Edge)
+ */
+function getURLClass() {
+    if (typeof window !== 'undefined') {
+        return window.URL;
+    }
+
+    if (typeof (globalThis as { EdgeRuntime?: string }).EdgeRuntime === 'string') {
+        return globalThis.URL;
+    }
+
+    return nodeUrl.URL;
+}
+
+const URL = getURLClass();
 
 function parseUrlParams(query: string): ParsedQuery {
     return queryString.parse(query, { arrayFormat: 'bracket' });


### PR DESCRIPTION
Currently the only issue I found that prevented the package from working on the Edge Runtime was usage of Node.js URL. This PR fixes this by adding an extra check for `EdgeRuntime` property on the global object and returning global `URL` property in that case.