### PR TITLE
Declare dedicated `search` param for Stories List/Search APIs

### DIFF
--- a/src/endpoints/Stories/types.ts
+++ b/src/endpoints/Stories/types.ts
@@ -79,6 +79,7 @@ export interface IncludeOptions<Include extends readonly (keyof Story.ExtraField
 }
 
 export interface ListOptions<Include extends readonly (keyof Story.ExtraFields)[]> {
+    search?: string;
     limit?: number;
     offset?: number;
     sortOrder?: SortOrder | string;


### PR DESCRIPTION
The param support was there long ago, but wasn't declared in the SDK