### PR TITLE
Make `Culture[code]` typing stricter

### DIFF
--- a/src/types/Category.ts
+++ b/src/types/Category.ts
@@ -5,7 +5,7 @@ export interface CategoryRef {
     display_name: string;
     display_description: string | null;
     i18n: {
-        [localeCode: string]: {
+        [localeCode: CultureRef['code']]: {
             description: string | null;
             locale: CultureRef;
             name: string;

--- a/src/types/Culture.ts
+++ b/src/types/Culture.ts
@@ -16,6 +16,15 @@ export namespace Culture {
     }
 
     export type LangCode = `${Lowercase<string>}`;
+    export type ScriptCode = string;
+    export type RegionCode = `${Uppercase<string>}`;
 
-    export type Code = `${LangCode}` | `${LangCode}_${string}`;
+    /**
+     * Primary locale code used everywhere in the Prezly app.
+     */
+    export type Code =
+        | `${LangCode}`
+        | `${LangCode}_${RegionCode}`
+        | `${LangCode}_${ScriptCode}`
+        | `${LangCode}_${ScriptCode}_${RegionCode}`;
 }

--- a/src/types/Culture.ts
+++ b/src/types/Culture.ts
@@ -1,10 +1,13 @@
+type LangCode = `${Lowercase<string>}`;
+type UnderscoreCode = `${LangCode}` | `${LangCode}_${string}`;
+
 export interface CultureRef {
-    code: string;
-    locale: string;
+    code: UnderscoreCode;
+    locale: UnderscoreCode;
     name: string;
     native_name: string;
-    direction: Culture.TextDirection;
-    language_code: string;
+    direction: `${Culture.TextDirection}`;
+    language_code: LangCode;
 }
 
 export type Culture = CultureRef;

--- a/src/types/Culture.ts
+++ b/src/types/Culture.ts
@@ -1,13 +1,10 @@
-type LangCode = `${Lowercase<string>}`;
-type UnderscoreCode = `${LangCode}` | `${LangCode}_${string}`;
-
 export interface CultureRef {
-    code: UnderscoreCode;
-    locale: UnderscoreCode;
+    code: Culture.Code;
+    locale: Culture.Code;
     name: string;
     native_name: string;
     direction: `${Culture.TextDirection}`;
-    language_code: LangCode;
+    language_code: Culture.LangCode;
 }
 
 export type Culture = CultureRef;
@@ -17,4 +14,8 @@ export namespace Culture {
         LTR = 'ltr',
         RTL = 'rtl',
     }
+
+    export type LangCode = `${Lowercase<string>}`;
+
+    export type Code = `${LangCode}` | `${LangCode}_${string}`;
 }

--- a/src/types/Culture.ts
+++ b/src/types/Culture.ts
@@ -36,4 +36,8 @@ export namespace Culture {
     export type LangCode = `${Lowercase<string>}`;
     export type ScriptCode = string;
     export type RegionCode = `${Uppercase<string>}`;
+
+    export function isoCode(code: Code): IsoCode {
+        return code.replace('_', '-') as IsoCode;
+    }
 }

--- a/src/types/Culture.ts
+++ b/src/types/Culture.ts
@@ -15,10 +15,6 @@ export namespace Culture {
         RTL = 'rtl',
     }
 
-    export type LangCode = `${Lowercase<string>}`;
-    export type ScriptCode = string;
-    export type RegionCode = `${Uppercase<string>}`;
-
     /**
      * Primary locale code used everywhere in the Prezly app.
      */
@@ -36,4 +32,8 @@ export namespace Culture {
         | `${LangCode}-${RegionCode}`
         | `${LangCode}-${ScriptCode}`
         | `${LangCode}-${ScriptCode}-${RegionCode}`;
+
+    export type LangCode = `${Lowercase<string>}`;
+    export type ScriptCode = string;
+    export type RegionCode = `${Uppercase<string>}`;
 }

--- a/src/types/Culture.ts
+++ b/src/types/Culture.ts
@@ -27,4 +27,13 @@ export namespace Culture {
         | `${LangCode}_${RegionCode}`
         | `${LangCode}_${ScriptCode}`
         | `${LangCode}_${ScriptCode}_${RegionCode}`;
+
+    /**
+     * Locale ISO code to be used in HTML attributes.
+     */
+    export type IsoCode =
+        | `${LangCode}`
+        | `${LangCode}-${RegionCode}`
+        | `${LangCode}-${ScriptCode}`
+        | `${LangCode}-${ScriptCode}-${RegionCode}`;
 }


### PR DESCRIPTION
To avoid mistakes of misusing ISO code with dashes as Prezly Culture codes.

E.g. `nl_BE` vs `nl-BE`

This problem shines in the `@prezly/theme-kit-intl` package, where different types of codes are being used in different contexts.

I saw this approach in the Next.js codebase: [alternative-urls-types.ts:418-423](https://github.com/vercel/next.js/blob/99e584c70e6277d06c0aca2a8c822f154988adde/packages/next/src/lib/metadata/types/alternative-urls-types.ts#L418-L423)