### PR TITLE
[DEV-11988] Fix Category `i18n` property typing

### DIFF
--- a/src/types/Category.ts
+++ b/src/types/Category.ts
@@ -4,9 +4,9 @@ export interface CategoryRef {
     id: number;
     display_name: string;
     display_description: string | null;
-    i18n: Partial<{
-        [localeCode: Culture.Code]: Category.Translation;
-    }>;
+    i18n: {
+        [localeCode in Culture.Code]: Category.Translation;
+    };
     stories_number: number;
 }
 

--- a/src/types/SortOrder.ts
+++ b/src/types/SortOrder.ts
@@ -91,12 +91,12 @@ function toObject(sortOrder: string | SortOrder): SortOrder {
 
 function parseColumn(column: string): SortOrder.Column {
     if (column.startsWith('+')) {
-        const [, name] = column.split('+');
+        const [, name = ''] = column.split('+');
         validateColumnName(name);
         return { name, direction: SortOrder.Direction.ASC };
     }
     if (column.startsWith('-')) {
-        const [, name] = column.split('-');
+        const [, name = ''] = column.split('-');
         validateColumnName(name);
         return { name, direction: SortOrder.Direction.DESC };
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,8 @@
         "isolatedModules": true,
         "downlevelIteration": true,
         "strict": true,
+        // @see https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess
+        "noUncheckedIndexedAccess": true,
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
Followup on #260  

With previous approach, TS would always think that `Object.values(category.i18n)` can contain undefined. So doing any map/forEach would require to add unnecessary checks for emptiness.

The original intent behind declaring `i18n` as `Parital<...>` is better to guard against by enabling the `noUncheckedIndexedAccess` TS compiler options.

See https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess