### PR TITLE
[DEV-12120] Implement a new Stories API to fetch story by slug

### DIFF
--- a/src/endpoints/Stories/Client.ts
+++ b/src/endpoints/Stories/Client.ts
@@ -1,7 +1,7 @@
 import type { DeferredJobsApiClient } from '../../api';
 import { ApiError, HttpCodes } from '../../http';
 import { routing } from '../../routing';
-import type { ExtendedStory, Story } from '../../types';
+import type { ExtendedStory, Query, Story } from '../../types';
 import { SortOrder } from '../../types';
 
 import type {
@@ -171,6 +171,27 @@ export class Client {
             headers: acceptedFormatsHeader(formats),
             query: { include },
         });
+        return story;
+    }
+
+    async getBySlug<Options extends IncludeOptions & { formats?: Formats; query?: Query }>(
+        slug: Story['slug'],
+        options?: Exactly<Options, IncludeOptions & { formats?: Formats; query?: Query }>,
+    ): Promise<ExtendedStory & InferExtraFields<Options>> {
+        if (slug.includes('/') || slug.includes('\\')) {
+            throw new Error('Story slugs cannot contain slashes.');
+        }
+
+        const { include, query, formats } = options ?? {};
+
+        const { story } = await this.apiClient.post<{
+            story: ExtendedStory & InferExtraFields<Options>;
+        }>(`${routing.storiesUrl}/by-slug/${slug}`, {
+            headers: acceptedFormatsHeader(formats),
+            query: { include },
+            payload: { query },
+        });
+
         return story;
     }
 


### PR DESCRIPTION
Implementation: https://github.com/prezly/prezly/pull/14124

The difference with `search()` is that this one can find relocated stories by its former slug values, even after slug has been changed.

The consumer code is expected to perform a redirect when a story slug doesn't match the one coming from the request.