### PR TITLE
[CARE-4340] `CategoryRef` does not have `stories_number` property

### DIFF
--- a/src/types/Category.ts
+++ b/src/types/Category.ts
@@ -7,7 +7,6 @@ export interface CategoryRef {
     i18n: {
         [localeCode: Culture.Code]: Category.Translation;
     };
-    stories_number: number;
 }
 
 export interface Category extends CategoryRef {


### PR DESCRIPTION
It's only present in the full `Category` object, which is already declared as needed:

https://github.com/prezly/javascript-sdk/blob/312713e6f2c612d29402fe0abdc2d93ba6991265/src/types/Category.ts#L12-L15