### PR TITLE
[CARE-4547] Fix - Return promise when hitting the order endpoint

### DIFF
--- a/src/endpoints/NewsroomContacts/Client.ts
+++ b/src/endpoints/NewsroomContacts/Client.ts
@@ -53,7 +53,7 @@ export function createClient(api: DeferredJobsApiClient) {
 
     async function order(newsroomId: NewsroomId, payload: ReorderRequest): Promise<void> {
         const url = routing.newsroomContactsOrderUrl.replace(':newsroom_id', String(newsroomId));
-        api.post(url, {
+        return api.post(url, {
             payload,
         });
     }


### PR DESCRIPTION
The promise was never returned so any consumer code waiting for the API call to finish would happen instantly.