### PR TITLE
[DEV-12202] Drop `custom_slug` property from StoryRef

### DIFF
--- a/src/types/Story.ts
+++ b/src/types/Story.ts
@@ -17,7 +17,6 @@ export interface StoryRef {
     id: number;
     title: string;
     slug: string;
-    custom_slug: string | null;
 
     status: Story.Status;
     /**


### PR DESCRIPTION
It was a mistake -- the API backend does not provide it for StoryRef.

Introduced by me in #268 