### PR TITLE
Feature - Add site property to NewsroomContact type

### DIFF
--- a/src/types/NewsroomContact.ts
+++ b/src/types/NewsroomContact.ts
@@ -1,6 +1,7 @@
 import type { UploadedImage } from '@prezly/uploads';
 
 import type { CultureRef } from './Culture';
+import type { NewsroomRef } from './Newsroom';
 
 export interface NewsroomContactRef {
     uuid: string;
@@ -33,4 +34,5 @@ export interface NewsroomContact extends Omit<NewsroomContactRef, 'avatar_url'> 
      * List of locales this contact can be displayed for.
      */
     display_locales: CultureRef[];
+    site: NewsroomRef;
 }


### PR DESCRIPTION
The API returns this property but it is not declared in the type.