### PR TITLE
[CARE-6230] Feature - Store integrationRunUuid in coverage entry

### DIFF
--- a/src/endpoints/Coverage/types.ts
+++ b/src/endpoints/Coverage/types.ts
@@ -9,6 +9,7 @@ import type {
     Story,
     Query,
     SortOrder,
+    CoverageIntegrationRun,
 } from '../../types';
 
 export type Scope = { story: Story['id'] } | null;
@@ -55,7 +56,9 @@ export interface UpdateRequest {
     page?: number | null;
 }
 
-export interface CreateRequest extends UpdateRequest {}
+export interface CreateRequest extends UpdateRequest {
+    integrationRunUuid?: CoverageIntegrationRun['uuid'] | null;
+}
 
 export interface ListOptions {
     includeDeleted?: boolean;

--- a/src/endpoints/Coverage/types.ts
+++ b/src/endpoints/Coverage/types.ts
@@ -9,7 +9,6 @@ import type {
     Story,
     Query,
     SortOrder,
-    CoverageIntegrationRun,
 } from '../../types';
 
 export type Scope = { story: Story['id'] } | null;
@@ -57,7 +56,7 @@ export interface UpdateRequest {
 }
 
 export interface CreateRequest extends UpdateRequest {
-    integrationRunUuid?: CoverageIntegrationRun['uuid'] | null;
+    integration_run?: CoverageEntry['integration_run'];
 }
 
 export interface ListOptions {

--- a/src/types/CoverageEntry.ts
+++ b/src/types/CoverageEntry.ts
@@ -3,6 +3,7 @@ import type { UploadedFile, UploadedImage } from '@prezly/uploads';
 import type { OEmbedInfo } from './common';
 import type { Contact } from './Contact';
 import type { CountryRef } from './Country';
+import type { CoverageIntegrationRun } from './CoverageIntegrationRun';
 import type { CultureRef } from './Culture';
 import type { NewsroomRef } from './Newsroom';
 import type { Story } from './Story';
@@ -15,6 +16,7 @@ export interface CoverageEntry {
      * @see uuid
      */
     id: number;
+    integrationRunUuid: CoverageIntegrationRun['uuid'] | null;
     display_name: string;
     is_deleted: boolean;
     headline: string;

--- a/src/types/CoverageEntry.ts
+++ b/src/types/CoverageEntry.ts
@@ -16,7 +16,7 @@ export interface CoverageEntry {
      * @see uuid
      */
     id: number;
-    integrationRunUuid: CoverageIntegrationRun['uuid'] | null;
+    integration_run: CoverageIntegrationRun['id'] | CoverageIntegrationRun['uuid'] | null;
     display_name: string;
     is_deleted: boolean;
     headline: string;


### PR DESCRIPTION
@marko-ogg please implement related property on back-end side. Also let me know if the property should be renamed.
I've noticed that we have both `id` and `uuid` props in integration run entry, so I am unsure if I've chosen the correct one for referencing (uuid).