### PR TITLE
[DEV-18539] Lift `baseUrl` logic to the `HttpClient` level

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -82,12 +82,11 @@ export function createClient({
     headers = {},
     fetch,
 }: ClientOptions): Client {
-    const http = createHttpClient({ fetch });
+    const http = createHttpClient({ fetch, baseUrl });
     const api = createDeferredJobsApiClient(
         http,
         createApiClient(http, {
             accessToken,
-            baseUrl,
             headers,
         }),
     );

--- a/src/api/ApiClient.ts
+++ b/src/api/ApiClient.ts
@@ -1,32 +1,23 @@
 import type { ApiResponse, HeadersMap, HttpClient, Params, ParamsWithPayload } from '../http';
-import { stripSlashes } from '../utils';
 
 import { DEFAULT_USER_AGENT } from './constants';
 
 export interface Options {
     accessToken: string;
-    baseUrl: string;
     headers: HeadersMap;
 }
 
 export type ApiClient = ReturnType<typeof createApiClient>;
 
-export function createApiClient(http: HttpClient, { accessToken, baseUrl, headers }: Options) {
+export function createApiClient(http: HttpClient, { accessToken, headers }: Options) {
     const defaultHeaders = {
         authorization: `Bearer ${accessToken}`,
         'User-Agent': DEFAULT_USER_AGENT,
         ...headers,
     };
 
-    function buildEndpointUrl(endpointUri: string): string {
-        return `${stripSlashes(baseUrl)}/${stripSlashes(endpointUri)}`;
-    }
-
-    function get<V = any>(
-        endpointUri: string,
-        { headers, query }: Params = {},
-    ): Promise<ApiResponse<V>> {
-        return http.get<V>(buildEndpointUrl(endpointUri), {
+    function get<V = any>(url: string, { headers, query }: Params = {}): Promise<ApiResponse<V>> {
+        return http.get<V>(url, {
             headers: {
                 ...defaultHeaders,
                 ...headers,
@@ -36,10 +27,10 @@ export function createApiClient(http: HttpClient, { accessToken, baseUrl, header
     }
 
     function post<V = any>(
-        endpointUri: string,
+        url: string,
         { headers, payload, query }: ParamsWithPayload = {},
     ): Promise<ApiResponse<V>> {
-        return http.post<V>(buildEndpointUrl(endpointUri), {
+        return http.post<V>(url, {
             headers: {
                 ...defaultHeaders,
                 ...headers,
@@ -50,10 +41,10 @@ export function createApiClient(http: HttpClient, { accessToken, baseUrl, header
     }
 
     function put<V = any>(
-        endpointUri: string,
+        url: string,
         { headers, payload, query }: ParamsWithPayload = {},
     ): Promise<ApiResponse<V>> {
-        return http.put<V>(buildEndpointUrl(endpointUri), {
+        return http.put<V>(url, {
             headers: {
                 ...defaultHeaders,
                 ...headers,
@@ -64,10 +55,10 @@ export function createApiClient(http: HttpClient, { accessToken, baseUrl, header
     }
 
     function patch<V = any>(
-        endpointUri: string,
+        url: string,
         { headers, payload, query }: ParamsWithPayload = {},
     ): Promise<ApiResponse<V>> {
-        return http.patch<V>(buildEndpointUrl(endpointUri), {
+        return http.patch<V>(url, {
             headers: {
                 ...defaultHeaders,
                 ...headers,
@@ -78,10 +69,10 @@ export function createApiClient(http: HttpClient, { accessToken, baseUrl, header
     }
 
     function doDelete<V = any>(
-        endpointUri: string,
+        url: string,
         { headers, payload, query }: ParamsWithPayload = {},
     ): Promise<ApiResponse<V>> {
-        return http.delete<V>(buildEndpointUrl(endpointUri), {
+        return http.delete<V>(url, {
             headers: {
                 ...defaultHeaders,
                 ...headers,

--- a/src/http/HttpClient.ts
+++ b/src/http/HttpClient.ts
@@ -12,12 +12,20 @@ export interface HttpClient {
     delete<V = any>(url: string, params?: ParamsWithPayload): Promise<ApiResponse<V>>;
 }
 
-export function createHttpClient(options: { fetch?: Fetch } = {}): HttpClient {
+export function createHttpClient(options: { baseUrl?: string; fetch?: Fetch } = {}): HttpClient {
+    const baseUrl = options.baseUrl ?? null;
     const fetchImpl = options.fetch ?? fetch;
+
+    function resolveUrl(url: string) {
+        if (baseUrl) {
+            return new URL(url, baseUrl).toString();
+        }
+        return url;
+    }
 
     return {
         get(url, { headers, query } = {}) {
-            return createRequest(fetchImpl, url, {
+            return createRequest(fetchImpl, resolveUrl(url), {
                 headers,
                 method: Method.GET,
                 query,
@@ -25,7 +33,7 @@ export function createHttpClient(options: { fetch?: Fetch } = {}): HttpClient {
         },
 
         post(url: string, { headers, payload, query } = {}) {
-            return createRequest(fetchImpl, url, {
+            return createRequest(fetchImpl, resolveUrl(url), {
                 headers,
                 method: Method.POST,
                 payload,
@@ -34,7 +42,7 @@ export function createHttpClient(options: { fetch?: Fetch } = {}): HttpClient {
         },
 
         put(url, { headers, payload, query } = {}) {
-            return createRequest(fetchImpl, url, {
+            return createRequest(fetchImpl, resolveUrl(url), {
                 headers,
                 method: Method.PUT,
                 payload,
@@ -43,7 +51,7 @@ export function createHttpClient(options: { fetch?: Fetch } = {}): HttpClient {
         },
 
         patch(url: string, { headers, payload, query } = {}) {
-            return createRequest(fetchImpl, url, {
+            return createRequest(fetchImpl, resolveUrl(url), {
                 headers,
                 method: Method.PATCH,
                 payload,
@@ -52,7 +60,7 @@ export function createHttpClient(options: { fetch?: Fetch } = {}): HttpClient {
         },
 
         delete(url: string, { headers, payload, query } = {}) {
-            return createRequest(fetchImpl, url, {
+            return createRequest(fetchImpl, resolveUrl(url), {
                 headers,
                 method: Method.DELETE,
                 payload,


### PR DESCRIPTION
Otherwise, the DeferredApiClient logic fails requesting a path-only Jobs API url (`/v2/jobs`).