### PR TITLE
Fix - Drop `uploadcare_assets_group_uuid` from extra fields

### DIFF
--- a/src/endpoints/Stories/types.ts
+++ b/src/endpoints/Stories/types.ts
@@ -330,7 +330,7 @@ export interface ChangeNewsroomUnsafeResponse {
 }
 
 const EXTENDED_STORY_INCLUDED_EXTRA_FIELDS_SHAPE: Record<
-    keyof Omit<ExtendedStory, keyof Story>,
+    keyof Omit<ExtendedStory, keyof Story | 'uploadcare_assets_group_uuid'>,
     boolean
 > = {
     thumbnail_image: true,
@@ -342,7 +342,6 @@ const EXTENDED_STORY_INCLUDED_EXTRA_FIELDS_SHAPE: Record<
     content: true,
     attached_gallery_content: true,
     referenced_entities: true,
-    uploadcare_assets_group_uuid: true,
 }; // satisfies Record<keyof Omit<ExtendedStory, keyof Story>, boolean>; // TODO: Use Typescript `satisfies` operator, when it's out of beta
 
 const ALL_EXTRA_FIELDS_SHAPE: Record<keyof Story.ExtraFields, boolean> = {

--- a/src/endpoints/Stories/types.ts
+++ b/src/endpoints/Stories/types.ts
@@ -330,7 +330,7 @@ export interface ChangeNewsroomUnsafeResponse {
 }
 
 const EXTENDED_STORY_INCLUDED_EXTRA_FIELDS_SHAPE: Record<
-    keyof Omit<ExtendedStory, keyof Story | 'uploadcare_assets_group_uuid'>,
+    keyof Omit<ExtendedStory, keyof Story>,
     boolean
 > = {
     thumbnail_image: true,
@@ -363,7 +363,6 @@ const ALL_EXTRA_FIELDS_SHAPE: Record<keyof Story.ExtraFields, boolean> = {
     referenced_entities: true,
     'campaigns.count': true,
     'pitches.count': true,
-    uploadcare_assets_group_uuid: true,
 }; // satisfies Record<keyof Story.OnDemandFields, boolean>; // TODO: Use Typescript `satisfies` operator, when it's out of beta
 
 export const ALL_EXTRA_FIELDS = Object.keys(

--- a/src/types/Story.ts
+++ b/src/types/Story.ts
@@ -166,6 +166,8 @@ export interface Story {
     pinned_by: UserRef | null;
 
     seo_settings: SEOSettings;
+
+    uploadcare_assets_group_uuid: string | null;
 }
 
 export namespace Story {
@@ -296,8 +298,6 @@ export namespace Story {
          * Number of pitches linked to this story.
          */
         'pitches.count': number;
-
-        uploadcare_assets_group_uuid: string | null;
     }
 
     /*
@@ -501,5 +501,4 @@ export interface ExtendedStory
             | 'content'
             | 'attached_gallery_content'
             | 'referenced_entities'
-            | 'uploadcare_assets_group_uuid'
         > {}


### PR DESCRIPTION
`uploadcare_assets_group_uuid` is returned by default and doesn't need to be an extra field