### PR TITLE
Feature - Add offset and limit to Pagination

### DIFF
--- a/src/types/common/Pagination.ts
+++ b/src/types/common/Pagination.ts
@@ -2,7 +2,9 @@
  * @see https://api.prezly.com/v2/common/schema.json#/definitions/Pagination
  */
 export interface Pagination {
+    limit: number;
     matched_records_number: number;
+    offset: number;
     total_records_number: number;
 }
 


### PR DESCRIPTION
Noticed that the API returns these properties as part of the `pagination`. Not sure if it's always returned though?

Either way, it's nice because we can use it to determine whether we can load another page when using infinite query.