### PR TITLE
Feature - Add active_theme_preset property to Newsroom

### DIFF
--- a/src/types/Newsroom.ts
+++ b/src/types/Newsroom.ts
@@ -1,7 +1,7 @@
 import type { UploadedImage } from '@prezly/uploads';
 
 import type { CultureRef } from './Culture';
-import type { NewroomThemeRef } from './NewsroomTheme';
+import type { NewroomThemeRef, NewsroomThemePreset } from './NewsroomTheme';
 
 export interface NewsroomRef {
     uuid: string;
@@ -151,6 +151,8 @@ export interface Newsroom extends NewsroomRef {
         visits_last_7_days: number | null;
         visits_last_7_days_previous: number | null;
     };
+
+    active_theme_preset: NewsroomThemePreset;
 }
 
 export namespace Newsroom {


### PR DESCRIPTION
This property was already declared in the [Prezly app](https://github.com/prezly/prezly/blob/2203bafb4167205ebcce4cf8cb944ad671f1da20/apps/backend/resources/javascripts/%40types/%40prezly/sdk/index.d.ts#L7) but now we need it in the Bea theme as well so I'm just adding it here.