### PR TITLE
[DEV-21181] Feature - Extend `Newsroom` API presentation

### DIFF
--- a/src/types/ContactTag.ts
+++ b/src/types/ContactTag.ts
@@ -1,7 +1,6 @@
+import type { Iso8601DateTime } from './common';
 import type { ContactTagGroupRef } from './ContactTagGroup';
 import type { UserRef } from './User';
-
-type Iso8601DateTime = string;
 
 export interface ContactTagRef {
     id: number;

--- a/src/types/ContactsExport.ts
+++ b/src/types/ContactsExport.ts
@@ -1,6 +1,5 @@
+import type { Iso8601DateTime } from './common';
 import type { UserRef } from './User';
-
-type Iso8601DateTime = string;
 
 export interface ContactsExport {
     uuid: string;

--- a/src/types/CoverageIntegration.ts
+++ b/src/types/CoverageIntegration.ts
@@ -1,9 +1,8 @@
+import type { Iso8601DateTime } from './common';
 import type { CoverageEntry } from './CoverageEntry';
 import type { CoverageIntegrationRun } from './CoverageIntegrationRun';
 import type { NewsroomRef } from './Newsroom';
 import type { UserRef } from './User';
-
-type Iso8601DateTime = string;
 
 export interface CoverageIntegration {
     id: number;

--- a/src/types/CoverageIntegrationRun.ts
+++ b/src/types/CoverageIntegrationRun.ts
@@ -1,6 +1,5 @@
+import type { Iso8601DateTime } from './common';
 import type { CoverageIntegrationRef } from './CoverageIntegration';
-
-type Iso8601DateTime = string;
 
 export interface CoverageIntegrationRun {
     id: number;

--- a/src/types/Newsroom.ts
+++ b/src/types/Newsroom.ts
@@ -1,9 +1,8 @@
 import type { UploadedImage } from '@prezly/uploads';
 
+import type { Iso8601DateTime } from './common';
 import type { CultureRef } from './Culture';
 import type { NewroomThemeRef, NewsroomThemePreset } from './NewsroomTheme';
-
-type Iso8601DateTime = string;
 
 export interface NewsroomRef {
     uuid: string;

--- a/src/types/common/Iso8601DateTime.ts
+++ b/src/types/common/Iso8601DateTime.ts
@@ -1,0 +1,1 @@
+export type Iso8601DateTime = string;

--- a/src/types/common/index.ts
+++ b/src/types/common/index.ts
@@ -1,3 +1,4 @@
+export * from './Iso8601DateTime';
 export * from './Notification';
 export * from './OEmbedInfo';
 export * from './Pagination';


### PR DESCRIPTION
App changes: https://github.com/prezly/prezly/pull/17333

- Add `created_at` to Newsroom and NewsroomRef API objects
- Add `domain` to NewsroomRef API object (previously: only on the full Newsroom object)