### PR TITLE
Add optional `hub` field to Newsroom type

### DIFF
--- a/src/types/Newsroom.ts
+++ b/src/types/Newsroom.ts
@@ -81,6 +81,7 @@ export interface NewsroomRef {
 
 export interface Newsroom extends NewsroomRef {
     is_hub: boolean;
+    hub?: { parent: Newsroom.HubPeer; siblings: Newsroom.HubPeer[] } | null;
     // extended details
     cultures: CultureRef[];
     campaigns_number: number;
@@ -140,6 +141,10 @@ export interface Newsroom extends NewsroomRef {
 }
 
 export namespace Newsroom {
+    export interface HubPeer extends NewsroomRef {
+        cultures: CultureRef[];
+    }
+
     export enum Status {
         ACTIVE = 'active', // i.e. "Live"
         INACTIVE = 'inactive', // i.e. "Not live"

--- a/src/types/Newsroom.ts
+++ b/src/types/Newsroom.ts
@@ -81,7 +81,7 @@ export interface NewsroomRef {
 
 export interface Newsroom extends NewsroomRef {
     is_hub: boolean;
-    hub?: { parent: Newsroom.HubPeer; siblings: Newsroom.HubPeer[] } | null;
+    hub: { parent: Newsroom.HubPeer; siblings: Newsroom.HubPeer[] } | null;
     // extended details
     cultures: CultureRef[];
     campaigns_number: number;
@@ -142,7 +142,7 @@ export interface Newsroom extends NewsroomRef {
 
 export namespace Newsroom {
     export interface HubPeer extends NewsroomRef {
-        cultures: CultureRef[];
+        cultures: (CultureRef & { is_default: boolean })[];
     }
 
     export enum Status {


### PR DESCRIPTION
## Summary

- Adds an optional `hub` field to the `Newsroom` type, mirroring the additive field introduced by [prezly/prezly#18567](https://github.com/prezly/prezly/pull/18567).
- Exposes `hub.parent` and `hub.siblings[]` (each a `NewsroomRef` + `cultures`) so theme/consumer code can render cross-site language pickers on HUB child newsrooms.
- New `Newsroom.HubPeer` interface captures the shape used for parent/siblings.

## Backend shape

- `hub: null` for standalone newsrooms and HUB parents
- `hub: { parent, siblings }` for HUB children

## Release coordination

Field is typed as optional (`hub?:`) on purpose — this lets us merge and release the SDK independently of the backend PR's deploy order without handing consumers a type that lies about runtime shape. Once the backend is live everywhere, we can drop the `?` in a follow-up.

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Reviewer confirms field shape matches the backend PR
- [ ] After backend 18567 deploys, verify SDK consumers can read `newsroom.hub` on a real HUB child