### PR TITLE
Add cross_site_translations field and newsroom param to translate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@prezly/sdk",
-    "version": "26.3.1",
+    "version": "26.4.0",
     "description": "Prezly API SDK",
     "type": "module",
     "main": "dist/index.cjs",

--- a/src/endpoints/Stories/Client.ts
+++ b/src/endpoints/Stories/Client.ts
@@ -228,7 +228,7 @@ export function createClient(api: DeferredJobsApiClient) {
         payload: TranslateRequest = {},
         options?: Exactly<Options, IncludeOptions & { formats?: Formats }>,
     ): Promise<ExtendedStory & InferExtraFields<Options>> {
-        const { culture, auto = false } = payload ?? {};
+        const { culture, auto = false, newsroom } = payload ?? {};
         const { include, formats } = options ?? {};
 
         const url = `${routing.storiesUrl}/${id}/translate`;
@@ -241,6 +241,7 @@ export function createClient(api: DeferredJobsApiClient) {
             payload: {
                 culture,
                 auto,
+                newsroom,
             },
         });
 

--- a/src/endpoints/Stories/types.ts
+++ b/src/endpoints/Stories/types.ts
@@ -311,6 +311,7 @@ export type UnscheduleRequest = UnpublishRequest;
 export interface TranslateRequest {
     culture?: CultureRef['code'];
     auto?: boolean;
+    newsroom?: Newsroom['uuid'] | Newsroom['id'];
 }
 
 export interface MoveRequest {
@@ -361,6 +362,7 @@ const ALL_EXTRA_FIELDS_SHAPE = {
     'campaigns.count': true,
     'pitches.count': true,
     'coverage.count': true,
+    cross_site_translations: true,
 } satisfies Record<keyof Story.ExtraFields, boolean>;
 
 export const ALL_EXTRA_FIELDS = Object.keys(

--- a/src/types/Story.ts
+++ b/src/types/Story.ts
@@ -303,6 +303,11 @@ export namespace Story {
          * Number of coverage entries linked to this story.
          */
         'coverage.count': number;
+
+        /**
+         * Translations of this story that exist in other newsrooms (cross-site translations).
+         */
+        cross_site_translations: StoryRef[];
     }
 
     /*


### PR DESCRIPTION
## Summary
- Adds `cross_site_translations: StoryRef[]` to `Story.ExtraFields` (and registers it in `ALL_EXTRA_FIELDS_SHAPE` so it's available via `include`)
- Adds optional `newsroom` param to `TranslateRequest`, forwarded by `Stories.translate()`, allowing translations to be created in another newsroom (cross-site)
- Bumps version to `26.4.0`

Companion to prezly/prezly#18650.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run` passes (48/48)
- [x] `npx biome ci` passes on changed files
- [x] CI green