### PR TITLE
Add `redirect_to_canonical_url` field to Newsroom

### DIFF
--- a/src/endpoints/Newsrooms/types.ts
+++ b/src/endpoints/Newsrooms/types.ts
@@ -148,6 +148,7 @@ export interface UpdateRequest {
 
     is_plausible_enabled?: boolean;
     is_white_labeled?: boolean;
+    redirect_to_canonical_url?: boolean;
 
     onetrust_cookie_consent?: {
         is_enabled?: boolean;

--- a/src/types/Newsroom.ts
+++ b/src/types/Newsroom.ts
@@ -124,6 +124,7 @@ export interface Newsroom extends NewsroomRef {
     is_subscription_form_enabled: boolean;
     auto_create_contacts_from_subscribers: boolean;
     is_white_labeled: boolean;
+    redirect_to_canonical_url: boolean;
 
     is_plausible_enabled: boolean;
     plausible_site_id: string;


### PR DESCRIPTION
## Summary
- Adds the per-newsroom `redirect_to_canonical_url: boolean` field to the `Newsroom` type
- Adds the matching optional field to `Newsrooms.UpdateRequest`

Mirrors the backend addition in prezly/prezly#18719, which exposes the field on the Newsroom API and accepts it in newsroom updates (gated server-side by the `STORY_CANONICAL_URL_REDIRECTION` license feature flag).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] Cut a new minor release (`26.5.0`) after merge and publish to NPM